### PR TITLE
Fix: Handle client aborts gracefully in Nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,8 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ignore_client_abort on;
+            proxy_buffering off;
         }
 
         # Cache-Control and Security


### PR DESCRIPTION
This change configures Nginx to ignore client aborts and disable proxy buffering. This will prevent Nginx from returning a 502 error when you disconnect during a file download.